### PR TITLE
fix: use direct undefined check in logic rules

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -16,7 +16,6 @@ import {
 } from './types'
 import { isLogicRule } from './utils'
 import { GraphQLResolveInfo } from 'graphql'
-import { isUndefined } from 'util'
 
 export class Rule implements IRule {
   readonly name: string
@@ -388,7 +387,7 @@ export class RuleChain extends LogicRule {
     async function iterate([rule, ...otherRules]: ShieldRule[]): Promise<
       IRuleResult[]
     > {
-      if (isUndefined(rule)) return []
+      if (rule === undefined) return []
       return rule.resolve(parent, args, ctx, info, options).then((res) => {
         if (res !== true) {
           return [res]
@@ -442,7 +441,7 @@ export class RuleRace extends LogicRule {
     async function iterate([rule, ...otherRules]: ShieldRule[]): Promise<
       IRuleResult[]
     > {
-      if (isUndefined(rule)) return []
+      if (rule === undefined) return []
       return rule.resolve(parent, args, ctx, info, options).then((res) => {
         if (res === true) {
           return [res]


### PR DESCRIPTION
Replaces the util.isUndefined import with a direct undefined check in the chain and race logic rules.